### PR TITLE
[FIX] Admin Login API 이슈 해결

### DIFF
--- a/src/util/FirebaseUtil.ts
+++ b/src/util/FirebaseUtil.ts
@@ -27,7 +27,7 @@ export const tryLogin = async (requestData: LoginUser): Promise<LoginResult> => 
 
     const loginDoc = await getDoc(doc(firestoreDB!, "Login", "admin"));
     const userList: Array<LoginUser> = loginDoc.get("user");
-    userList.forEach((userItem) => {
+    for(const userItem of userList){
         if(requestData.username === userItem.username){
             if(requestData.password === userItem.password){
                 return LoginResult.LOGIN_OK;
@@ -35,7 +35,7 @@ export const tryLogin = async (requestData: LoginUser): Promise<LoginResult> => 
                 return LoginResult.LOGIN_FAIL_PASSWORD;
             }
         }
-    });
+    }
 
     return LoginResult.LOGIN_FAIL_NO_ACCOUNT;
 }

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -9,8 +9,8 @@ export interface LoginUser {
     username: string
 }
 
-export enum LoginResult {
-    LOGIN_OK,
-    LOGIN_FAIL_NO_ACCOUNT,
-    LOGIN_FAIL_PASSWORD,
+export const enum LoginResult {
+    LOGIN_OK = "OK",
+    LOGIN_FAIL_NO_ACCOUNT = "FAIL_NO_ACCOUNT",
+    LOGIN_FAIL_PASSWORD = "FAIL_PASSWORD",
 }


### PR DESCRIPTION
## Summary
Admin 프로젝트의 Login API가 정상 동작하지 않는 이슈를 해결하였습니다.

## Description
- Login 결과에 관계없이 `LOGIN_FAIL_NO_ACCOUNT`가 반환되는 문제를 해결하였습니다.
- 기존 로직에서 사용했던 `forEach` 구문은 `Array`의 각 요소에 대한 `Callback Function` 형식으로 실행하기에, 실제로 의도했던 바와 같이 전체 함수를 `return` 하는 것이 아닌, 해당 시점의 `Callback Function` Scope에 대해서만 1회성으로 `return`이 이루어졌습니다.
- 해당 구문을 `for...of` 형식으로 변경하여 의도한 바와 같이 전체 함수에 대한 `return`이 이루어지도록 수정하였습니다.
- `LoginResult` Enum 항목에 대해, 지정된 String 형식의 값을 정의하였습니다. FE측에서 API 연동 시, 해당 값을 참조하여 결과를 비교하시면 됩니다.