### PR TITLE
[DEV] Admin Recruit API 구현

### DIFF
--- a/src/app/api/login/tryLogin/route.ts
+++ b/src/app/api/login/tryLogin/route.ts
@@ -1,7 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
 import {corsHeader} from "@/util/CorsUtil";
-import {tryLogin} from "@/util/FirebaseUtil";
+import {checkLogin} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
 export async function POST(req: NextRequest) {
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     };
 
     const loginBody: LoginUser = JSON.parse(await req.text());
-    const loginResult: LoginResult = await tryLogin(loginBody);
+    const loginResult: LoginResult = await checkLogin(loginBody);
     apiResult.RESULT_DATA = loginResult;
 
     if(loginResult === LoginResult.LOGIN_OK){

--- a/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
@@ -1,6 +1,25 @@
 import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/util/Interface";
+import {corsHeader} from "@/util/CorsUtil";
+import {getRecruitSubmissionDetail} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
-export async function GET(_: NextRequest) {
-    return NextResponse.json({ status: 200 });
+export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    const submissionDetail = await getRecruitSubmissionDetail(params.id);
+    if(submissionDetail === undefined || submissionDetail.timestamp == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
+
+    apiResult.RESULT_DATA = submissionDetail;
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
+++ b/src/app/api/recruit/getSubmissionDetail/[id]/route.ts
@@ -1,14 +1,23 @@
 import {NextRequest, NextResponse} from "next/server";
-import {API_RESULT} from "@/util/Interface";
+import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
 import {corsHeader} from "@/util/CorsUtil";
-import {getRecruitSubmissionDetail} from "@/util/FirebaseUtil";
+import {checkLogin, getRecruitSubmissionDetail} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
-export async function GET(_: NextRequest, {params}: {params: {id: string}}) {
+export async function POST(req: NextRequest, {params}: {params: {id: string}}) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
+    }
+
+    const loginBody: LoginUser = JSON.parse(await req.text());
+    const loginResult: LoginResult = await checkLogin(loginBody);
+    if(loginResult !== LoginResult.LOGIN_OK) {
+        apiResult.RESULT_CODE = 100
+        apiResult.RESULT_MSG = "Unauthorized"
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
     }
 
     const submissionDetail = await getRecruitSubmissionDetail(params.id);

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -1,6 +1,25 @@
 import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT} from "@/util/Interface";
+import {corsHeader} from "@/util/CorsUtil";
+import {getRecruitSubmissionList} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
-    return NextResponse.json({ status: 200 });
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    const submissionList = await getRecruitSubmissionList();
+    if(submissionList === undefined || submissionList.data.length == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
+
+    apiResult.RESULT_DATA = submissionList;
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -17,7 +17,8 @@ export async function POST(req: NextRequest) {
         apiResult.RESULT_CODE = 100
         apiResult.RESULT_MSG = "Unauthorized"
         apiResult.RESULT_DATA = undefined;
-        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });    }
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
 
     const submissionList = await getRecruitSubmissionList();
     if(submissionList === undefined || submissionList.data.length == 0){

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -1,7 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
-import {API_RESULT} from "@/util/Interface";
+import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
 import {corsHeader} from "@/util/CorsUtil";
-import {getRecruitSubmissionList} from "@/util/FirebaseUtil";
+import {checkLogin, getRecruitSubmissionList} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
 export async function POST(req: NextRequest) {
@@ -10,6 +10,14 @@ export async function POST(req: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    const loginBody: LoginUser = JSON.parse(await req.text());
+    const loginResult: LoginResult = await checkLogin(loginBody);
+    if(loginResult !== LoginResult.LOGIN_OK) {
+        apiResult.RESULT_CODE = 100
+        apiResult.RESULT_MSG = "Unauthorized"
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });    }
 
     const submissionList = await getRecruitSubmissionList();
     if(submissionList === undefined || submissionList.data.length == 0){

--- a/src/app/api/recruit/getSubmissionList/route.ts
+++ b/src/app/api/recruit/getSubmissionList/route.ts
@@ -4,7 +4,7 @@ import {corsHeader} from "@/util/CorsUtil";
 import {getRecruitSubmissionList} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
-export async function GET(_: NextRequest) {
+export async function POST(req: NextRequest) {
     const apiResult: API_RESULT = {
         RESULT_CODE: 200,
         RESULT_MSG: "Success",

--- a/src/util/FirebaseUtil.ts
+++ b/src/util/FirebaseUtil.ts
@@ -1,8 +1,14 @@
 import {FirebaseApp, initializeApp} from "@firebase/app";
-import {doc, getDoc, getFirestore} from "@firebase/firestore";
+import {collection, doc, getDoc, getDocs, getFirestore} from "@firebase/firestore";
 import {Firestore} from "firebase/firestore";
 import dotenv from "dotenv";
-import {LoginResult, LoginUser} from "@/util/Interface";
+import {
+    LoginResult,
+    LoginUser,
+    RecruitSubmissionDetail,
+    RecruitSubmissionItem,
+    RecruitSubmissionList
+} from "@/util/Interface";
 
 let firebaseApp: FirebaseApp | null = null;
 let firestoreDB: Firestore | null = null;
@@ -38,4 +44,89 @@ export const checkLogin = async (requestData: LoginUser): Promise<LoginResult> =
     }
 
     return LoginResult.LOGIN_FAIL_NO_ACCOUNT;
+}
+
+export const getRecruitSubmissionDetail = async (studentID: string) => {
+    initFirebase();
+
+    const submissionDetail: RecruitSubmissionDetail = {
+        age: "",
+        answer: [],
+        college: "",
+        department: "",
+        grade: "",
+        id: "",
+        isPrivacyCollectAgree: false,
+        name: "",
+        phone: "",
+        timestamp: 0
+    }
+
+    const recruitSubmissionDocs = await getDocs(collection(firestoreDB!, "Recruit"));
+    if(recruitSubmissionDocs.empty){
+        return submissionDetail;
+    }
+
+    for(const recruitSubmissionDoc of recruitSubmissionDocs.docs){
+        if(recruitSubmissionDoc.get("id") == studentID){
+            submissionDetail.age = recruitSubmissionDoc.get("age");
+            submissionDetail.answer = recruitSubmissionDoc.get("answer");
+            submissionDetail.college = recruitSubmissionDoc.get("college");
+            submissionDetail.department = recruitSubmissionDoc.get("department");
+            submissionDetail.grade = recruitSubmissionDoc.get("grade");
+            submissionDetail.id = recruitSubmissionDoc.get("id");
+            submissionDetail.isPrivacyCollectAgree = recruitSubmissionDoc.get("isPrivacyCollectAgree");
+            submissionDetail.name = recruitSubmissionDoc.get("name");
+            submissionDetail.phone = recruitSubmissionDoc.get("phone");
+            submissionDetail.timestamp = Number.parseInt(recruitSubmissionDoc.id);
+
+            break;
+        }
+    }
+
+    return submissionDetail;
+}
+
+export const getRecruitSubmissionList = async () => {
+    initFirebase();
+
+    const submissionList: RecruitSubmissionList = {
+        count: 0,
+        data: []
+    }
+
+    const recruitSubmissionDocs = await getDocs(collection(firestoreDB!, "Recruit"));
+    if(recruitSubmissionDocs.empty){
+        return submissionList;
+    }
+
+    for(const recruitSubmissionDoc of recruitSubmissionDocs.docs){
+        const submissionItem: RecruitSubmissionItem = {
+            age: recruitSubmissionDoc.get("age"),
+            answer: recruitSubmissionDoc.get("answer"),
+            college: recruitSubmissionDoc.get("college"),
+            department: recruitSubmissionDoc.get("department"),
+            grade: recruitSubmissionDoc.get("grade"),
+            id: recruitSubmissionDoc.get("id"),
+            isPrivacyCollectAgree: recruitSubmissionDoc.get("isPrivacyCollectAgree"),
+            name: recruitSubmissionDoc.get("name"),
+            phone: recruitSubmissionDoc.get("phone"),
+            timestamp: Number.parseInt(recruitSubmissionDoc.id)
+        }
+
+        if(submissionItem.age !== undefined
+            && submissionItem.answer !== undefined
+            && submissionItem.college !== undefined
+            && submissionItem.department !== undefined
+            && submissionItem.grade !== undefined
+            && submissionItem.id !== undefined
+            && submissionItem.name !== undefined
+            && submissionItem.phone !== undefined
+            && submissionItem.timestamp !== undefined){
+            submissionList.count++;
+            submissionList.data.push(submissionItem);
+        }
+    }
+
+    return submissionList;
 }

--- a/src/util/FirebaseUtil.ts
+++ b/src/util/FirebaseUtil.ts
@@ -22,7 +22,7 @@ const initFirebase = () => {
     }
 }
 
-export const tryLogin = async (requestData: LoginUser): Promise<LoginResult> => {
+export const checkLogin = async (requestData: LoginUser): Promise<LoginResult> => {
     initFirebase();
 
     const loginDoc = await getDoc(doc(firestoreDB!, "Login", "admin"));

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: LoginResult | undefined
+    RESULT_DATA: LoginResult | RecruitSubmissionDetail | RecruitSubmissionList | undefined
 }
 
 export interface LoginUser {
@@ -13,4 +13,35 @@ export const enum LoginResult {
     LOGIN_OK = "OK",
     LOGIN_FAIL_NO_ACCOUNT = "FAIL_NO_ACCOUNT",
     LOGIN_FAIL_PASSWORD = "FAIL_PASSWORD",
+}
+
+export interface RecruitSubmissionDetail {
+    age: string
+    answer: Array<string>
+    college: string
+    department: string
+    grade: string
+    id: string
+    isPrivacyCollectAgree: boolean
+    name: string
+    phone: string
+    timestamp: number
+}
+
+export interface RecruitSubmissionItem {
+    age: string
+    answer: Array<string>
+    college: string
+    department: string
+    grade: string
+    id: string
+    isPrivacyCollectAgree: boolean
+    name: string
+    phone: string
+    timestamp: number
+}
+
+export interface RecruitSubmissionList {
+    count: number
+    data: Array<RecruitSubmissionItem>
 }


### PR DESCRIPTION
## Summary
Admin 프로젝트에 Recruit API를 구현하였습니다.

## Description
- 매 동작 시, 로그인 정보를 확인하기 위한 함수를 FirebaseUtil에 구현하였습니다. 기존 로그인 검증용 함수의 이름을 변경하였습니다.
- Recruit 항목의 리스트 조회 함수를 구현하였습니다. `HTTP POST` 요청을 `/api/recruit/getSubmissionList` 형식으로 전달하되, 로그인 API와 마찬가지로 계정 정보를 body에 전달하면 됩니다.
- Recruit 항목의 특정 항목 상세조회 함수를 구현하였습니다. `HTTP POST` 요청을 `/api/recruit/getSubmissionDetail/[id]` 형식으로 전달하되, 로그인 API와 마찬가지로 계정 정보를 body에 전달하면 됩니다.