### PR TITLE
[DEV] Admin Question API 추가 구현

### DIFF
--- a/src/app/api/recruit/getAvailability/route.ts
+++ b/src/app/api/recruit/getAvailability/route.ts
@@ -1,7 +1,12 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
 import {corsHeader} from "@/util/CorsUtil";
-import {checkLogin, getRecruitQuestionList, getRecruitSubmissionList} from "@/util/FirebaseUtil";
+import {
+    checkLogin,
+    getRecruitAvailability,
+    getRecruitQuestionList,
+    getRecruitSubmissionList
+} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
@@ -10,6 +15,8 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    apiResult.RESULT_DATA = await getRecruitAvailability();
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getAvailability/route.ts
+++ b/src/app/api/recruit/getAvailability/route.ts
@@ -1,0 +1,15 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
+import {corsHeader} from "@/util/CorsUtil";
+import {checkLogin, getRecruitQuestionList, getRecruitSubmissionList} from "@/util/FirebaseUtil";
+
+export const dynamic = "force-dynamic";
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/app/api/recruit/getQuestionList/route.ts
+++ b/src/app/api/recruit/getQuestionList/route.ts
@@ -1,7 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
 import {corsHeader} from "@/util/CorsUtil";
-import {checkLogin, getRecruitSubmissionList} from "@/util/FirebaseUtil";
+import {checkLogin, getRecruitQuestionList, getRecruitSubmissionList} from "@/util/FirebaseUtil";
 
 export const dynamic = "force-dynamic";
 export async function GET(_: NextRequest) {
@@ -10,6 +10,16 @@ export async function GET(_: NextRequest) {
         RESULT_MSG: "Success",
         RESULT_DATA: undefined
     }
+
+    const questionList = await getRecruitQuestionList();
+    if(questionList === undefined || questionList.count == 0){
+        apiResult.RESULT_CODE = 100;
+        apiResult.RESULT_MSG = "An Error Occurred";
+        apiResult.RESULT_DATA = undefined;
+        return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+    }
+
+    apiResult.RESULT_DATA = questionList;
 
     return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
 }

--- a/src/app/api/recruit/getQuestionList/route.ts
+++ b/src/app/api/recruit/getQuestionList/route.ts
@@ -1,0 +1,15 @@
+import {NextRequest, NextResponse} from "next/server";
+import {API_RESULT, LoginResult, LoginUser} from "@/util/Interface";
+import {corsHeader} from "@/util/CorsUtil";
+import {checkLogin, getRecruitSubmissionList} from "@/util/FirebaseUtil";
+
+export const dynamic = "force-dynamic";
+export async function GET(_: NextRequest) {
+    const apiResult: API_RESULT = {
+        RESULT_CODE: 200,
+        RESULT_MSG: "Success",
+        RESULT_DATA: undefined
+    }
+
+    return NextResponse.json(apiResult, { status: 200, headers: corsHeader });
+}

--- a/src/util/FirebaseUtil.ts
+++ b/src/util/FirebaseUtil.ts
@@ -4,7 +4,7 @@ import {Firestore} from "firebase/firestore";
 import dotenv from "dotenv";
 import {
     LoginResult,
-    LoginUser, RecruitQuestionList,
+    LoginUser, RecruitAvailability, RecruitQuestionList,
     RecruitSubmissionDetail,
     RecruitSubmissionItem,
     RecruitSubmissionList
@@ -44,6 +44,18 @@ export const checkLogin = async (requestData: LoginUser): Promise<LoginResult> =
     }
 
     return LoginResult.LOGIN_FAIL_NO_ACCOUNT;
+}
+
+export const getRecruitAvailability = async () => {
+    initFirebase();
+
+    const recruitAvailDoc = await getDoc(doc(firestoreDB!, "RecruitAvailability", "availability"));
+    const recruitAvail: RecruitAvailability = {
+        isAvail: recruitAvailDoc.get("isAvail"),
+        message: recruitAvailDoc.get("message"),
+    };
+
+    return recruitAvail;
 }
 
 export const getRecruitQuestionList = async () => {

--- a/src/util/FirebaseUtil.ts
+++ b/src/util/FirebaseUtil.ts
@@ -4,7 +4,7 @@ import {Firestore} from "firebase/firestore";
 import dotenv from "dotenv";
 import {
     LoginResult,
-    LoginUser,
+    LoginUser, RecruitQuestionList,
     RecruitSubmissionDetail,
     RecruitSubmissionItem,
     RecruitSubmissionList
@@ -45,6 +45,20 @@ export const checkLogin = async (requestData: LoginUser): Promise<LoginResult> =
 
     return LoginResult.LOGIN_FAIL_NO_ACCOUNT;
 }
+
+export const getRecruitQuestionList = async () => {
+    initFirebase();
+
+    const questionDoc = await getDoc(doc(firestoreDB!, "Question", "data"));
+    const questionList: RecruitQuestionList = {
+        count: questionDoc.get("count"),
+        list: questionDoc.get("list")
+    }
+
+    return questionList;
+}
+
+
 
 export const getRecruitSubmissionDetail = async (studentID: string) => {
     initFirebase();

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -15,6 +15,11 @@ export const enum LoginResult {
     LOGIN_FAIL_PASSWORD = "FAIL_PASSWORD",
 }
 
+export interface RecruitAvailability {
+    isAvail: boolean
+    message: string
+}
+
 export interface RecruitQuestionList {
     count: number
     list: Array<string>

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -15,6 +15,11 @@ export const enum LoginResult {
     LOGIN_FAIL_PASSWORD = "FAIL_PASSWORD",
 }
 
+export interface RecruitQuestionList {
+    count: number
+    list: Array<string>
+}
+
 export interface RecruitSubmissionDetail {
     age: string
     answer: Array<string>

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: LoginResult | RecruitSubmissionDetail | RecruitSubmissionList | undefined
+    RESULT_DATA: LoginResult | RecruitQuestionList | RecruitSubmissionDetail | RecruitSubmissionList | undefined
 }
 
 export interface LoginUser {

--- a/src/util/Interface.ts
+++ b/src/util/Interface.ts
@@ -1,7 +1,7 @@
 export interface API_RESULT {
     RESULT_CODE: number
     RESULT_MSG: string
-    RESULT_DATA: LoginResult | RecruitQuestionList | RecruitSubmissionDetail | RecruitSubmissionList | undefined
+    RESULT_DATA: LoginResult | RecruitAvailability | RecruitQuestionList | RecruitSubmissionDetail | RecruitSubmissionList | undefined
 }
 
 export interface LoginUser {


### PR DESCRIPTION
## Summary
Admin 프로젝트에 Recruit API를 추가로 구현하였습니다.

## Description
- Recruit의 서술형 질문 목록을 받아오는 API를 구현하였습니다.
- Recruit의 활성화 여부 및 안내 메시지를 받아오는 API를 구현하였습니다.
- 두 API는 각각 `/api/recruit/getAvailability` 및 `/api/recruit/getQuestionList`를 Endpoint로 하며, HTTP GET 형식으로 동작합니다. 별도의 로그인 정보는 필요하지 않습니다.